### PR TITLE
Fix discriminated union type generation

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,27 +121,7 @@ function convertDependencies(schema) {
   }
 
   for (const key in deps) {
-    const foo = {
-      oneOf: [
-        {
-          not: {
-            required: [key],
-          },
-        },
-        {
-          required: [].concat(key, deps[key]),
-        },
-      ],
-    };
-
-    if (typeof deps[key] === "object") {
-      foo.oneOf[1].required = [key];
-      const dependencyObject = deps[key];
-      for (const dependencyKey in dependencyObject) {
-        foo.oneOf[1][dependencyKey] = dependencyObject[dependencyKey];
-      }
-    }
-    schema.allOf.push(foo);
+    schema.allOf.push(deps[key]);
   }
   return schema;
 }


### PR DESCRIPTION
Previously, discriminated union types were generated in a way that made them inaccessible from Typescript.